### PR TITLE
Stake-ified the directory, SMS, and Email pages.

### DIFF
--- a/includes/nav.php
+++ b/includes/nav.php
@@ -47,7 +47,11 @@
 	<?php endwhile; ?>
 
 	<b>Membership</b>
-	<a href="/directory"><i class="fa fa-list-alt"></i>Directory</a>
+	<a href="/directory?stake"><i class="fa fa-list-alt"></i>Stake Directory</a>
+	
+	<b>Send</b>
+	<a href="/sms"><i class="fa fa-comments"></i>Texts</a>
+	<a href="/email"><i class="fa fa-envelope"></i>Emails</a>
 <?php endif; ?>
 	
 	<br>

--- a/lib/classes/StakeLeader.php
+++ b/lib/classes/StakeLeader.php
@@ -340,5 +340,9 @@ class StakeLeader
 		$this->Salt = salt();
 		$this->Password = hashPwd($newPwd, $this->Salt);
 	}
+	
+	public function FirstName() {
+		return trim($this->Title . ' ' . $this->FirstName);
+	}
 }
 ?>

--- a/member.php
+++ b/member.php
@@ -6,9 +6,22 @@ if (!isset($_GET['id']))
 	header("Location: /directory");
 
 $mem = Member::Load($_GET['id']);
+if (!$mem)
+	header("Location: /directory");
 
 // No member with given ID number, or member is not in the same ward
-if (!$mem || $mem->WardID != $WARD->ID())
+$memInWard = $mem->WardID != $WARD->ID();
+$memInLeaderStake = false;
+
+if ($LEADER != null) {
+	$r = DB::Run("SELECT StakeID FROM Wards WHERE ID='{$mem->WardID}'");
+	$row = mysql_fetch_object($r);
+	if ($row->StakeID == $LEADER->StakeID) {
+		$memInLeaderStake = true;
+	}
+}
+
+if (!$memInWard && !$memInLeaderStake)
 	header("Location: /directory");
 
 $isCurrent = $MEMBER && $MEMBER->ID() == $mem->ID();

--- a/pages/desktop/directory.php
+++ b/pages/desktop/directory.php
@@ -1,8 +1,16 @@
 <?php
 protectPage(0, true);
 
-// Get a list of all ward members
-$q = "SELECT ID FROM Members WHERE WardID='{$WARD->ID()}' ORDER BY FirstName ASC, LastName ASC";
+$IS_STAKE_VIEW = $MEMBER == null && $LEADER != null && array_key_exists('stake', $_GET);
+
+if ($IS_STAKE_VIEW) {
+	// Get a list of all stake members
+	$q = "SELECT ID FROM Members WHERE WardID IN (SELECT ID FROM Wards WHERE StakeID = '{$LEADER->StakeID}') ORDER BY FirstName ASC, LastName ASC";
+} else {
+	// Get a list of all ward members
+	$q = "SELECT ID FROM Members WHERE WardID='{$WARD->ID()}' ORDER BY FirstName ASC, LastName ASC";
+}
+
 $r = DB::Run($q);
 $memberCount = mysql_num_rows($r);
 
@@ -21,7 +29,8 @@ $memberCount = mysql_num_rows($r);
 //$allBdays = $MEMBER ? $MEMBER->HasPrivilege(PRIV_EXPORT_BDATE) : true;
 
 // Get a list of the questions this person is allowed to see
-$permissions = $USER->Permissions(true);
+// Show no survey questions if we're in stake-mode
+$permissions = $IS_STAKE_VIEW ? [] : $USER->Permissions(true);
 
 // Array of SurveyQuestion objects which this user can see
 $questions = array(); // (populating in a moment...)
@@ -44,7 +53,7 @@ $cKey = userAgentContains("Macintosh") ? "command" : "Ctrl";
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Directory &mdash; <?php echo $WARD ? $WARD->Name." Ward" : SITE_NAME; ?></title>
+		<title><?= $IS_STAKE_VIEW ? 'Stake ' : '' ?>Directory &mdash; <?php echo $WARD ? $WARD->Name." Ward" : SITE_NAME; ?></title>
 		<?php include "includes/head.php"; ?>
 		<script src="/resources/js/directory_filter.js"></script>
 		<style>

--- a/pages/mobile/directory.php
+++ b/pages/mobile/directory.php
@@ -1,8 +1,16 @@
 <?php
 protectPage(0, true);
 
-// Get a list of all ward members
-$q = "SELECT ID FROM Members WHERE WardID='{$WARD->ID()}' ORDER BY FirstName ASC, LastName ASC";
+$IS_STAKE_VIEW = $MEMBER == null && $LEADER != null && array_key_exists('stake', $_GET);
+
+if ($IS_STAKE_VIEW) {
+	// Get a list of all stake members
+	$q = "SELECT ID FROM Members WHERE WardID IN (SELECT ID FROM Wards WHERE StakeID = '{$LEADER->StakeID}') ORDER BY FirstName ASC, LastName ASC";
+} else {
+	// Get a list of all ward members
+	$q = "SELECT ID FROM Members WHERE WardID='{$WARD->ID()}' ORDER BY FirstName ASC, LastName ASC";
+}
+
 $r = DB::Run($q);
 $memberCount = mysql_num_rows($r);
 
@@ -10,7 +18,7 @@ $memberCount = mysql_num_rows($r);
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Directory &mdash; <?php echo $WARD ? $WARD->Name." Ward" : SITE_NAME; ?></title>
+		<title><?= $IS_STAKE_VIEW ? 'Stake ' : '' ?>Directory &mdash; <?php echo $WARD ? $WARD->Name." Ward" : SITE_NAME; ?></title>
 		<?php include "includes/head.php"; ?>
 		<script src="/resources/js/directory_filter.js"></script>
 		<style>


### PR DESCRIPTION
Now when visiting the stake directory, and not from a ward-specific link, the entire stake is listed on one page. This is triggered by the presence of the URL suffix "?stake". Under this view, no survey questions are shown. Incidentally, this dramatically speeds up load/render time.

If a stake leader visits the SMS/Email pages, they are given a list of all stake members to select from. FHE options are disallowed.
